### PR TITLE
Add languages support

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -27,7 +27,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('api_key')->isRequired()->cannotBeEmpty()->end()
                     ->scalarNode('api_url')->defaultValue(null)->end()
                     ->scalarNode('units')->defaultValue(null)->end()
-                    ->scalarNode('langs')->defaultValue(null)->end()
+                    ->scalarNode('lang')->defaultValue(null)->end()
                 ->end()
         ;
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('api_key')->isRequired()->cannotBeEmpty()->end()
                     ->scalarNode('api_url')->defaultValue(null)->end()
                     ->scalarNode('units')->defaultValue(null)->end()
+                    ->scalarNode('langs')->defaultValue(null)->end()
                 ->end()
         ;
 

--- a/src/DependencyInjection/EndroidOpenWeatherMapExtension.php
+++ b/src/DependencyInjection/EndroidOpenWeatherMapExtension.php
@@ -24,6 +24,7 @@ class EndroidOpenWeatherMapExtension extends Extension
         $container->setParameter('endroid.openweathermap.api_key', $config['api_key']);
         $container->setParameter('endroid.openweathermap.api_url', $config['api_url']);
         $container->setParameter('endroid.openweathermap.units', $config['units']);
+        $container->setParameter('endroid.openweathermap.langs', $config['langs']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/DependencyInjection/EndroidOpenWeatherMapExtension.php
+++ b/src/DependencyInjection/EndroidOpenWeatherMapExtension.php
@@ -24,7 +24,7 @@ class EndroidOpenWeatherMapExtension extends Extension
         $container->setParameter('endroid.openweathermap.api_key', $config['api_key']);
         $container->setParameter('endroid.openweathermap.api_url', $config['api_url']);
         $container->setParameter('endroid.openweathermap.units', $config['units']);
-        $container->setParameter('endroid.openweathermap.langs', $config['langs']);
+        $container->setParameter('endroid.openweathermap.lang', $config['lang']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,4 +1,4 @@
 services:
     endroid.openweathermap.client:
         class: Endroid\OpenWeatherMap\Client
-        arguments: [ %endroid.openweathermap.api_key%, %endroid.openweathermap.api_url%, %endroid.openweathermap.units%, %endroid.openweathermap.langs% ]
+        arguments: [ %endroid.openweathermap.api_key%, %endroid.openweathermap.api_url%, %endroid.openweathermap.units%, %endroid.openweathermap.lang% ]

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,4 +1,4 @@
 services:
     endroid.openweathermap.client:
         class: Endroid\OpenWeatherMap\Client
-        arguments: [ %endroid.openweathermap.api_key%, %endroid.openweathermap.api_url%, %endroid.openweathermap.units% ]
+        arguments: [ %endroid.openweathermap.api_key%, %endroid.openweathermap.api_url%, %endroid.openweathermap.units%, %endroid.openweathermap.langs% ]


### PR DESCRIPTION
Hello I make somme modification for support other language (french for me)

I post here the modification for client.php because I don't found the repository

Possible to add in config.yml
endroid_open_weather_map:
    api_key: "533924788ffc2af6bba04525f21a5e8a"
    units: "metric"
    langs: "fr"

thanks for your bundle 
Ronan

<?php

/*
 * (c) Jeroen van den Enden <info@endroid.nl>
 *
 * This source file is subject to the MIT license that is bundled
 * with this source code in the file LICENSE.
 */

namespace Endroid\OpenWeatherMap;

use GuzzleHttp\Client as GuzzleClient;
use stdClass;

class Client
{
    /**
     * @var string
     */
    protected $apiUrl = 'http://api.openweathermap.org/data/2.5/';

    /**
     * @var string
     */
    protected $apiKey;

    /**
     * @var string
     */
    protected $units = 'metric';

    /**
     * @var string
     */
    protected $langs = 'fr';

    /**
     * @var GuzzleClient
     */
    protected $guzzleClient;

    /**
     * Class constructor.
     *
     * @param $apiKey
     * @param null $apiUrl
     * @param null $units
     */
    public function __construct($apiKey, $apiUrl = null, $units = null, $lang = null)
    {
        $this->apiKey = $apiKey;

        if ($apiUrl) {
            $this->apiUrl = $apiUrl;
        }

        if ($units) {
            $this->units = $units;
        }

        if ($langs) {
            $this->langs = $langs;
        }

        $this->guzzleClient = new GuzzleClient();
    }

    /**
     * Performs a query to the OpenWeatherMap API.
     *
     * @param $name
     * @param array $parameters
     *
     * @return stdClass
     */
    public function query($name, $parameters = array())
    {
        // Pass the API key
        if (!isset($parameters['APPID'])) {
            $parameters['APPID'] = $this->apiKey;
        }

        // Pass the desired units
        if (!isset($parameters['units'])) {
            $parameters['units'] = $this->units;
        }

        if (!isset($parameters['langs'])) {
            $parameters['langs'] = $this->langs;
        }

        // Part 2 : base url
        $baseUrl = $this->apiUrl.$name;

        // The call has to be made against the base url + query string
        $requestQueryParts = array();
        foreach ($parameters as $key => $value) {
            $requestQueryParts[] = $key.'='.rawurlencode($value);
        }
        $baseUrl .= '?'.implode('&', $requestQueryParts);

        $response = $this->guzzleClient->get($baseUrl);
        $response = json_decode($response->getBody()->getContents());

        return $response;
    }

    /**
     * Returns the current weather for a city.
     *
     * @param $city
     * @param array $parameters
     *
     * @return stdClass
     */
    public function getWeather($city, $parameters = array())
    {
        return $this->doGenericQuery('weather', $city, $parameters);
    }

    /**
     * Returns the forecast for a city.
     *
     * @param $city
     * @param $days
     * @param array $parameters
     *
     * @return stdClass
     */
    public function getForecast($city, $days = null, $parameters = array())
    {
        if ($days) {
            if (!empty($parameters)) {
                $parameters['cnt'] = $days;
            } else {
                $parameters = array('cnt' => $days);
            }
        }

        return $this->doGenericQuery('forecast/daily', $city, $parameters);
    }

    /**
     * @param $query
     * @param $city
     * @param array $parameters
     *
     * @return stdClass
     */
    private function doGenericQuery($query, $city, $parameters = array())
    {
        if (is_numeric($city)) {
            $parameters['id'] = $city;
        } else {
            $parameters['q'] = $city;
        }

        $response = $this->query($query, $parameters);

        return $response;
    }
}
